### PR TITLE
Update index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,13 +2,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Redirect to the Open-CMSIS-Pack toolbox documentation page after 0 seconds</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/Open-CMSIS-Pack/devtools/tree/main/tools/README.md">
+<meta http-equiv="refresh" content="0; URL=https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/README.md">
 <meta name="keywords" content="automatic redirection">
 </head>
 
 <body>
 
-If the automatic redirection is failing, click <a href="https://github.com/Open-CMSIS-Pack/devtools/tree/main/tools/README.md">open CMSIS-Toolbox documentation</a>.
+If the automatic redirection is failing, click <a href="https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/README.md">open CMSIS-Toolbox documentation</a>.
 
 </body>
 </html>


### PR DESCRIPTION
The redirect URL needs to be updated to point to the documentation in cmsis-toolbox repo rather than the devtools repository