### PR TITLE
Ship x86_64 binaries on arm macs via vcpkg

### DIFF
--- a/.github/ctools.json.in
+++ b/.github/ctools.json.in
@@ -40,7 +40,7 @@
 				"strip": 1
 			}
 		},
-		"osx and x64": {
+		"osx": {
 			"install": {
 				"untar": "https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases/download/${CTOOLS_VERSION}/cmsis-toolbox-darwin-amd64.tar.gz",
 				"sha256": "${CTOOLS_DARWIN_AMD64_SHA}",


### PR DESCRIPTION
Addresses Open-CMSIS-Pack/cmsis-toolbox#27