### PR TITLE
Fix broken link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,7 @@ This variable points to the [CMSIS-Pack Root Directory](https://github.com/Open-
   MacOS       | ${HOME}/.cache/arm/packs
   WSL_Windows | ${LOCALAPPDATA}/Arm/Packs
 
-> Note: If you do not have a CMSIS-Pack root yet, use [**cpackget**](../../cpackget/docs/cpackget.md) to initialize your repository.
+> Note: If you do not have a CMSIS-Pack root yet, use [**cpackget**](../docs/cpackget.md) to initialize your repository.
 
 #### **TOOLCHAIN Registration**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,7 @@ This variable points to the [CMSIS-Pack Root Directory](https://github.com/Open-
   MacOS       | ${HOME}/.cache/arm/packs
   WSL_Windows | ${LOCALAPPDATA}/Arm/Packs
 
-> Note: If you do not have a CMSIS-Pack root yet, use [**cpackget**](../docs/cpackget.md) to initialize your repository.
+> Note: If you do not have a CMSIS-Pack root yet, use [**cpackget**](./cpackget.md) to initialize your repository.
 
 #### **TOOLCHAIN Registration**
 


### PR DESCRIPTION
The link to cpackget.md is incorrectly and returns a 404 error. This change provides the correct link.