### PR TITLE
Restrict workflow to run on document change

### DIFF
--- a/.github/workflows/global.yaml
+++ b/.github/workflows/global.yaml
@@ -1,6 +1,9 @@
 name: global
 on:
   pull_request:
+    paths:
+      - '!docs/**'
+      - '!README.md'
   release:
     types: [ published ]
 jobs:

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -6,10 +6,13 @@ on:
     paths:
       - '.github/workflows/toolbox.yml'
       - '**'
+      - '!docs/**'
+      - '!README.md'
   pull_request:
     paths:
       - '.github/workflows/toolbox.yml'
       - '**'
+      - '!docs/**'
   release:
     types: [published]
 
@@ -229,6 +232,7 @@ jobs:
     needs: [ create_archives ]
     timeout-minutes: 15
     runs-on: ${{ matrix.config.os }}
+    name: 'Test (${{ matrix.config.target }}, ${{ matrix.config.arch }})'
     strategy:
       fail-fast: true
       matrix:
@@ -291,48 +295,17 @@ jobs:
     needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
-      - name: Download test report windows-amd64
+      - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: toolbox-test-windows-amd64
-          path: testreports/
-
-      - name: Download test report windows-arm64
-        uses: actions/download-artifact@v3
-        with:
-          name: toolbox-test-windows-arm64
-          path: testreports/
-
-      - name: Download unit test report linux-amd64
-        uses: actions/download-artifact@v3
-        with:
-          name: toolbox-test-linux-amd64
-          path: testreports/
-
-      - name: Download unit test report linux-arm64
-        uses: actions/download-artifact@v3
-        with:
-          name: toolbox-test-linux-arm64
-          path: testreports/
-
-      - name: Download unit test report darwin-amd64
-        uses: actions/download-artifact@v3
-        with:
-          name: toolbox-test-darwin-amd64
-          path: testreports/
-
-      - name: Download unit test report darwin-arm64
-        uses: actions/download-artifact@v3
-        with:
-          name: toolbox-test-darwin-arm64
-          path: testreports/
+          path: artifacts
 
       - name: publish test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           report_individual_runs: true
-          junit_files: "testreports/*.xml"
+          files: "artifacts/**/test-results-*.xml"
 
   release:
     if: ${{ github.event_name == 'release' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,5 @@ repos:
       entry: python3 scripts/check_copyright_notice.py
       language: system
       files: ^(libs\/|tools\/)
-      types_or: [c++, c, shell]
+      types_or: [python, shell]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------
+# Copyright (c) 2023 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+# -------------------------------------------------------
+
 import pytest
 
 def pytest_addoption(parser):

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------
+# Copyright (c) 2023 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+# -------------------------------------------------------
+
 from os import path
 import platform
 


### PR DESCRIPTION
The changes include:
- Restricting workflow run on documentation update
- Added copyright check in python files and run copyright checker on python scripts
- Cleanup  