### PR TITLE
Extend assets in nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,12 +121,51 @@ jobs:
         run: |
           GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cbuild2cmake${{ matrix.binary_extension }} ./cmd/cbuild2cmake
 
+      # Download and build cbridge executable
+      - name: Checkout cbridge repository
+        uses: actions/checkout@v4
+        with:
+          repository: Open-CMSIS-PACK/generator-bridge
+          path: cbridge
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cbridge/go.mod
+          cache-dependency-path: |
+            **/go.mod
+            **/go.sum
+
+      - name: Build cbridge executable
+        working-directory: cbridge
+        shell: bash
+        run: |
+          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cbridge${{ matrix.binary_extension }} ./cmd
+
       # Download projmgr and cbuildgen from nightly
       - name: Download Open-CMSIS-Pack/devtools nightly artifacts
         shell: bash
         run : |
           gh run download -D projmgr-${{ matrix.target }}-${{ matrix.arch }} ${{ steps.get_run_id.outputs.NIGHTLY_RUN_ID }} -n projmgr-${{ matrix.target }}-${{ matrix.arch }} -R Open-CMSIS-Pack/devtools
           gh run download -D cbuildgen-${{ matrix.target }}-${{ matrix.arch }} ${{ steps.get_run_id.outputs.NIGHTLY_RUN_ID }} -n cbuildgen-${{ matrix.target }}-${{ matrix.arch }} -R Open-CMSIS-Pack/devtools
+          gh run download -D packchk-${{ matrix.target }}-${{ matrix.arch }} ${{ steps.get_run_id.outputs.NIGHTLY_RUN_ID }} -n packchk-${{ matrix.target }}-${{ matrix.arch }} -R Open-CMSIS-Pack/devtools
+          gh run download -D svdconv-${{ matrix.target }}-${{ matrix.arch }} ${{ steps.get_run_id.outputs.NIGHTLY_RUN_ID }} -n svdconv-${{ matrix.target }}-${{ matrix.arch }} -R Open-CMSIS-Pack/devtools
+
+      - name: Unzip files
+        shell: bash
+        run: |
+          mkdir -p packchk
+          mkdir -p svdconv
+          packchk_dir="packchk-${{ matrix.target }}-${{ matrix.arch }}"
+          svdconv_dir="svdconv-${{ matrix.target }}-${{ matrix.arch }}"         
+          if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "macOS" ]]; then
+            tar -xvf ${packchk_dir}/packchk-*-${{ matrix.target }}-${{ matrix.arch }}.tbz2 -C packchk
+            tar -xvf ${svdconv_dir}/svdconv-*-${{ matrix.target }}-${{ matrix.arch }}.tbz2 -C svdconv
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            unzip ${packchk_dir}/packchk-\*-${{ matrix.target }}-${{ matrix.arch }}.zip -d packchk
+            unzip ${svdconv_dir}/svdconv-\*-${{ matrix.target }}-${{ matrix.arch }}.zip -d svdconv
+          fi
 
       - name: Checkout cmsis-toolbox repo
         uses: actions/checkout@v4
@@ -140,10 +179,14 @@ jobs:
           mkdir -p ./cmsis-toolbox/bin
           mkdir -p ./cmsis-toolbox/etc
           cp ./projmgr-${{ matrix.target }}-${{ matrix.arch }}/csolution${{ matrix.binary_extension }}      ./cmsis-toolbox/bin/csolution${{ matrix.binary_extension }}
-          cp ./cbuildgen-${{ matrix.target }}-${{ matrix.arch }}/cbuildgen${{ matrix.binary_extension }}*    ./cmsis-toolbox/bin/cbuildgen${{ matrix.binary_extension }}
-          cp ./cbuild/build/cbuild${{ matrix.binary_extension }}              ./cmsis-toolbox/bin/cbuild${{ matrix.binary_extension }}
-          cp ./cpackget/build/cpackget${{ matrix.binary_extension }}          ./cmsis-toolbox/bin/cpackget${{ matrix.binary_extension }}
-          cp ./cbuild2cmake/build/cbuild2cmake${{ matrix.binary_extension }}  ./cmsis-toolbox/bin/cbuild2cmake${{ matrix.binary_extension }}
+          cp ./cbuildgen-${{ matrix.target }}-${{ matrix.arch }}/cbuildgen${{ matrix.binary_extension }}*   ./cmsis-toolbox/bin/cbuildgen${{ matrix.binary_extension }}
+          cp ./packchk/packchk${{ matrix.binary_extension }}                                                ./cmsis-toolbox/bin/packchk${{ matrix.binary_extension }}
+          cp ./svdconv/svdconv${{ matrix.binary_extension }}                                                ./cmsis-toolbox/bin/svdconv${{ matrix.binary_extension }}
+          cp ./cbuild/build/cbuild${{ matrix.binary_extension }}                                            ./cmsis-toolbox/bin/cbuild${{ matrix.binary_extension }}
+          cp ./cpackget/build/cpackget${{ matrix.binary_extension }}                                        ./cmsis-toolbox/bin/cpackget${{ matrix.binary_extension }}
+          cp ./cbuild2cmake/build/cbuild2cmake${{ matrix.binary_extension }}                                ./cmsis-toolbox/bin/cbuild2cmake${{ matrix.binary_extension }}
+          cp ./cbridge/build/cbridge${{ matrix.binary_extension }}                                          ./cmsis-toolbox/bin/cbridge${{ matrix.binary_extension }}
+          cp ./cbridge/scripts/MCUXpresso_Config_Tools/${{ matrix.target }}-${{ matrix.arch }}/launch-MCUXpressoConfigTools*  ./cmsis-toolbox/bin/
           cp -r devtools/tools/projmgr/templates/*                ./cmsis-toolbox/etc
           cp -r devtools/tools/projmgr/schemas/*                  ./cmsis-toolbox/etc
           cp -r devtools/tools/buildmgr/cbuildgen/scripts/*       ./cmsis-toolbox/etc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,8 @@ on:
       - 'test/**'
       - '!test/RobotTests.md'
       - '!test/tests.py'
+env:
+  retention-days: 7
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,6 +45,8 @@ jobs:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Authenticate with GitHub CLI
         shell: bash
         run: |
@@ -167,7 +171,7 @@ jobs:
             unzip ${svdconv_dir}/svdconv-\*-${{ matrix.target }}-${{ matrix.arch }}.zip -d svdconv
           fi
 
-      - name: Checkout cmsis-toolbox repo
+      - name: Checkout Open-CMSIS-PACK/devtools repo
         uses: actions/checkout@v4
         with:
           repository: Open-CMSIS-PACK/devtools
@@ -178,6 +182,7 @@ jobs:
         run: |
           mkdir -p ./cmsis-toolbox/bin
           mkdir -p ./cmsis-toolbox/etc
+          mkdir -p ./cmsis-toolbox/doc
           cp ./projmgr-${{ matrix.target }}-${{ matrix.arch }}/csolution${{ matrix.binary_extension }}      ./cmsis-toolbox/bin/csolution${{ matrix.binary_extension }}
           cp ./cbuildgen-${{ matrix.target }}-${{ matrix.arch }}/cbuildgen${{ matrix.binary_extension }}*   ./cmsis-toolbox/bin/cbuildgen${{ matrix.binary_extension }}
           cp ./packchk/packchk${{ matrix.binary_extension }}                                                ./cmsis-toolbox/bin/packchk${{ matrix.binary_extension }}
@@ -191,6 +196,9 @@ jobs:
           cp -r devtools/tools/projmgr/schemas/*                  ./cmsis-toolbox/etc
           cp -r devtools/tools/buildmgr/cbuildgen/scripts/*       ./cmsis-toolbox/etc
           cp -r devtools/tools/buildmgr/cbuildgen/config/*        ./cmsis-toolbox/etc
+          cp ./docs/LICENSE.txt ./cmsis-toolbox
+          cp ./docs/index.html ./cmsis-toolbox/doc
+          touch ./cmsis-toolbox/cmsis-toolbox-${{ matrix.target }}-${{ matrix.arch }}-$(date '+%Y-%m-%d_%H-%M-%S')
 
       - name: Update toolchain config files
         if: ${{ matrix.target == 'windows' }}
@@ -207,6 +215,7 @@ jobs:
         with:
           name: cmsis-toolbox-${{ matrix.target }}-${{ matrix.arch }}
           path: cmsis-toolbox
+          retention-days: ${{ env.retention-days }}
 
   run-tests:
     needs: [ matrix_prep, create-toolbox ]
@@ -287,6 +296,7 @@ jobs:
         with:
           name: reports-${{ matrix.target }}-${{ matrix.arch }}
           path: reports-${{ matrix.target }}-${{ matrix.arch }}
+          retention-days: ${{ env.retention-days }}
 
   consolidate-report:
     if: always()
@@ -341,3 +351,4 @@ jobs:
       with:
         name: consolidated-reports
         path: artifacts/collective_robot_results
+        retention-days: ${{ env.retention-days }}


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/161
This change caters to the enhancement of the nighly cmsis-toolbox with:
- ./bin/cbridge
- ./bin/packchk
- ./bin/svdconv
- ./bin/launch-MCUXpressoConfigTools
- ./doc
- ./LICENSE.txt
- cmsis-toolbox_<os>-<arch>_<date>_<time> file
