### PR TITLE
Delay start of nightly build job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ name: nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 2 * * *'
   pull_request:
     paths:
       - '.github/workflows/nightly.yml'


### PR DESCRIPTION
Set the cron job to start 2 hours after the [devtools nightly build](https://github.com/Open-CMSIS-Pack/devtools/blob/main/.github/workflows/nightly.yml#L6)

Hint: [crontab guru](https://crontab.guru/#0_2_*_*_*)