### PR TITLE
Update deprecated GH action

### DIFF
--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -355,7 +355,7 @@ jobs:
           path: artifacts
 
       - name: publish test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           report_individual_runs: true


### PR DESCRIPTION
**Resolved warning**: Running this action via 'uses: EnricoMi/publish-unit-test-result-action/composite@v2 is deprecated! For details, see: https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2#running-as-a-composite-action