### PR TITLE
fix to AC6.22

### DIFF
--- a/test/vcpkg-configuration.json
+++ b/test/vcpkg-configuration.json
@@ -14,7 +14,7 @@
   "requires": {
     "arm:tools/kitware/cmake": "^3.27.1",
     "arm:tools/ninja-build/ninja": "^1.12.0",
-    "arm:compilers/arm/armclang":"^6.21.0",
+    "arm:compilers/arm/armclang":"6.22.0",
     "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
     "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.3.0",
     "arm:compilers/arm/llvm-embedded": "^17.0.1"


### PR DESCRIPTION
Temporarily fix to version AC 6.22 as registry url for AC 6.23 is not accessible.