### PR TITLE
Update test example to use specific component

### DIFF
--- a/test/data/library-rtos/project/project.cproject.yml
+++ b/test/data/library-rtos/project/project.cproject.yml
@@ -4,7 +4,7 @@ project:
     - component: ARM::CMSIS:CORE
     - component: ARM::Device:Startup&C Startup
     - component: ARM::CMSIS:RTOS2:Keil RTX5&Library
-    - component: ARM::CMSIS:OS Tick
+    - component: ARM::CMSIS:OS Tick:SysTick
 
   groups:
     - group: Source


### PR DESCRIPTION
## Changes
- Updated test example to use component with `csub` since there is no default implementation. In order to adapt changes from https://github.com/Open-CMSIS-Pack/devtools/pull/1861 

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [ ] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
