### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/global.yaml
+++ b/.github/workflows/global.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   copyright:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -403,8 +403,8 @@ jobs:
           - { os: macos-14, target: darwin, arch: arm64 }
           - { os: windows-2019, target: windows, arch: amd64}
           - { os: windows-2019, target: windows, arch: arm64}
-          - { os: ubuntu-20.04, target: linux, arch: amd64}
-          - { os: ubuntu-20.04, target: linux, arch: arm64}
+          - { os: ubuntu-22.04, target: linux, arch: amd64}
+          - { os: ubuntu-22.04, target: linux, arch: arm64}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
@@ -487,7 +487,7 @@ jobs:
   release:
     if: ${{ github.event_name == 'release' }}
     needs: [ tests ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.