### PR TITLE
Resolved errors during go setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,8 +49,13 @@ jobs:
     continue-on-error: true
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
-
+    env:
+      retention-days: 7
+      GOMODCACHE: ${{ github.workspace }}/.gocache
     steps:
+      - name: Clean Go mod cache
+        run: rm -rf ${{ env.GOMODCACHE }}
+      
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbuild/go.mod
-          cache-dependency-path: cbuild/go.sum
+          cache-dependency-path: 'cbuild/go.sum'
 
       - name: Build cbuild executable
         working-directory: cbuild
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cpackget/go.mod
-          cache-dependency-path: cpackget/go.sum
+          cache: false
 
       - name: Build cpackget executable
         working-directory: cpackget
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbuild2cmake/go.mod
-          cache-dependency-path: cbuild2cmake/go.sum
+          cache: false
 
       - name: Build cbuild2cmake executable
         working-directory: cbuild2cmake
@@ -145,7 +145,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: vidx2pidx/go.mod
-          cache-dependency-path: vidx2pidx/go.sum
+          cache: false
 
       - name: Build vidx2pidx executable
         working-directory: vidx2pidx

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,9 +85,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbuild/go.mod
-          cache-dependency-path: |
-            **/go.mod
-            **/go.sum
+          cache-dependency-path: cbuild/go.sum
 
       - name: Build cbuild executable
         working-directory: cbuild
@@ -107,9 +105,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cpackget/go.mod
-          cache-dependency-path: |
-            **/go.mod
-            **/go.sum
+          cache-dependency-path: cpackget/go.sum
 
       - name: Build cpackget executable
         working-directory: cpackget
@@ -129,9 +125,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbuild2cmake/go.mod
-          cache-dependency-path: |
-            **/go.mod
-            **/go.sum
+          cache-dependency-path: cbuild2cmake/go.sum
 
       - name: Build cbuild2cmake executable
         working-directory: cbuild2cmake
@@ -151,9 +145,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: vidx2pidx/go.mod
-          cache-dependency-path: |
-            **/go.mod
-            **/go.sum
+          cache-dependency-path: vidx2pidx/go.sum
 
       - name: Build vidx2pidx executable
         working-directory: vidx2pidx
@@ -173,9 +165,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbridge/go.mod
-          cache-dependency-path: |
-            **/go.mod
-            **/go.sum
+          cache-dependency-path: cbridge/go.sum
 
       - name: Build cbridge executable
         working-directory: cbridge

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,13 +49,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
-    env:
-      retention-days: 7
-      GOMODCACHE: ${{ github.workspace }}/.gocache
-    steps:
-      - name: Clean Go mod cache
-        run: rm -rf ${{ env.GOMODCACHE }}
-      
+    steps:     
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
@@ -78,6 +72,15 @@ jobs:
           RUN_ID=$(gh run list --limit 1 --workflow nightly --repo Open-CMSIS-Pack/devtools --json databaseId --jq '.[0].databaseId')
           echo "NIGHTLY_RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 
+      # Clean Go mod cache
+      - name: Clean Go mod cache
+        shell: bash
+        run: |
+          for dir in cbuild cpackget cbuild2cmake cbridge vidx2pidx; do
+            rm -rf "${{ github.workspace }}/.gocache/$dir"
+            mkdir -p "${{ github.workspace }}/.gocache/$dir"
+          done
+
       # Download and build cbuild executable
       - name: Checkout cbuild repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -90,13 +93,18 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: cbuild/go.mod
-          cache-dependency-path: 'cbuild/go.sum'
+          cache: false
 
       - name: Build cbuild executable
         working-directory: cbuild
         shell: bash
         run: |
-          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cbuild${{ matrix.binary_extension }} ./cmd/cbuild
+          export ABS_CBUILD_GOMODCACHE=$(realpath "${{ github.workspace }}/.gocache/cbuild")
+          GOOS=${{ matrix.target }} \
+          GOARCH=${{ matrix.arch }} \
+          GOMODCACHE=$ABS_CBUILD_GOMODCACHE \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
+            -o build/cbuild${{ matrix.binary_extension }} ./cmd/cbuild
 
       # Download and build cpackget executable
       - name: Checkout cpackget repository
@@ -116,7 +124,13 @@ jobs:
         working-directory: cpackget
         shell: bash
         run: |
-          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cpackget${{ matrix.binary_extension }} ./cmd
+          export ABS_CPACKGET_GOMODCACHE=$(realpath "${{ github.workspace }}/.gocache/cpackget")
+          GOMODCACHE=${{ github.workspace }}/.gocache/cpackget \
+          GOOS=${{ matrix.target }} \
+          GOARCH=${{ matrix.arch }} \
+          GOMODCACHE=$ABS_CPACKGET_GOMODCACHE \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
+            -o build/cpackget${{ matrix.binary_extension }} ./cmd  
 
       # Download and build cbuild2cmake executable
       - name: Checkout cbuild2cmake repository
@@ -136,7 +150,12 @@ jobs:
         working-directory: cbuild2cmake
         shell: bash
         run: |
-          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cbuild2cmake${{ matrix.binary_extension }} ./cmd/cbuild2cmake
+          export ABS_CBUILD2CMAKE_GOMODCACHE=$(realpath "${{ github.workspace }}/.gocache/cbuild2cmake")
+          GOOS=${{ matrix.target }} \
+          GOARCH=${{ matrix.arch }} \
+          GOMODCACHE=$ABS_CBUILD2CMAKE_GOMODCACHE \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
+            -o build/cbuild2cmake${{ matrix.binary_extension }} ./cmd/cbuild2cmake
 
       # Download and build vidx2pidx executable
       - name: Checkout vidx2pidx repository
@@ -156,7 +175,12 @@ jobs:
         working-directory: vidx2pidx
         shell: bash
         run: |
-          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/vidx2pidx${{ matrix.binary_extension }} ./cmd
+          export ABS_VIDX2PIDX_GOMODCACHE=$(realpath "${{ github.workspace }}/.gocache/vidx2pidx")
+          GOOS=${{ matrix.target }} \
+          GOARCH=${{ matrix.arch }} \
+          GOMODCACHE=$ABS_VIDX2PIDX_GOMODCACHE \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
+            -o build/vidx2pidx${{ matrix.binary_extension }} ./cmd
 
       # Download and build cbridge executable
       - name: Checkout cbridge repository
@@ -176,7 +200,12 @@ jobs:
         working-directory: cbridge
         shell: bash
         run: |
-          GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -ldflags "-X main.version=$(git describe --tags)" -o build/cbridge${{ matrix.binary_extension }} ./cmd
+          export ABS_CBRIDGE_GOMODCACHE=$(realpath "${{ github.workspace }}/.gocache/cbridge")
+          GOOS=${{ matrix.target }} \
+          GOARCH=${{ matrix.arch }} \
+          GOMODCACHE=$ABS_CBRIDGE_GOMODCACHE \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
+            -o build/cbridge${{ matrix.binary_extension }} ./cmd
 
       # Download projmgr and cbuildgen from nightly
       - name: Download Open-CMSIS-Pack/devtools nightly artifacts


### PR DESCRIPTION
## Fixes
- Go tries to extract and store dependencies in a shared cache path (~/go/pkg/mod by default).
- If multiple `go build` operations are run in parallel (even within the same job using matrix), they can race to write the same module files, causing file existence conflict

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
