### PR TITLE
Migrate workflows to windows-2022 due to upcoming deprecation of windows-2019

### DIFF
--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -402,8 +402,8 @@ jobs:
         config:
           - { os: macos-13, target: darwin, arch: amd64 }
           - { os: macos-14, target: darwin, arch: arm64 }
-          - { os: windows-2019, target: windows, arch: amd64}
-          - { os: windows-2019, target: windows, arch: arm64}
+          - { os: windows-2022, target: windows, arch: amd64}
+          - { os: windows-2022, target: windows, arch: arm64}
           - { os: ubuntu-22.04, target: linux, arch: amd64}
           - { os: ubuntu-22.04, target: linux, arch: arm64}
     steps:


### PR DESCRIPTION
## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
