### PR TITLE
Update nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -437,7 +437,7 @@ jobs:
           exit 1
 
   consolidate-report:
-    if: always()
+    if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox' && always()
     needs: [run-tests]
     runs-on: ubuntu-latest
     permissions: write-all

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -437,11 +437,10 @@ jobs:
           exit 1
 
   consolidate-report:
-    if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox' && always()
     needs: [run-tests]
     runs-on: ubuntu-latest
     permissions: write-all
-
+    if: needs.run-tests.result == 'success' || needs.run-tests.result == 'failure'
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2


### PR DESCRIPTION
The `consolidate-report` job should only run when the parent job i.e `run-tests` gives `success` or `failure `, not always

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
