### PR TITLE
Update toolbox version for E2E tests

### DIFF
--- a/test/vcpkg-configuration.json
+++ b/test/vcpkg-configuration.json
@@ -16,7 +16,7 @@
     "arm:tools/ninja-build/ninja": "1.12.0",
     "arm:compilers/arm/armclang":"6.24.0",
     "arm:compilers/arm/arm-none-eabi-gcc": "14.2.1",
-    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.9.0",
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.10.0",
     "arm:compilers/arm/llvm-embedded": "20.1.0",
     "arm:compilers/iar/cxarm": "9.60.4"
   }


### PR DESCRIPTION
## Fixes
- Update toolbox version to 2.10.0 required by E2E tests e.g. remote example: https://github.com/Arm-Examples/Hello_LPCXpresso55S69/blob/91a857fcf6517e723c974b55975240b8f93627ca/hello.csolution.yml
Observed in: https://github.com/Open-CMSIS-Pack/cmsis-toolbox/actions/runs/17020763985/job/48249867263

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
