### PR TITLE
Run E2E with CMake 4.2.1

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -33,12 +33,18 @@ jobs:
           inputFile: '.github/matrix_includes.json'
           filter: '[?runTests==`true`]'
 
+      
       - name: Generate matrix with cmake versions
         id: test-matrix
         shell: bash
         run: |
           base_matrix='${{ steps.test-matrix-base.outputs.matrix }}'
-          cmake_versions='["vcpkg","4.2.1"]'
+
+          # Read CMake version from vcpkg config
+          vcpkg_cmake_version=$(jq -r '.requires."arm:tools/kitware/cmake"' ./test/vcpkg-configuration.json)
+          echo "CMake version from vcpkg config: $vcpkg_cmake_version"
+
+          cmake_versions="[\"$vcpkg_cmake_version\", \"4.2.1\"]"
 
           # base_matrix is expected to be: { "include": [ ... ] }
           # produce: { "include": [ {..config.., cmake_version: ..}, ... ] }
@@ -57,6 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix_prep.outputs.test) }}
+    name: test(${{ matrix.runs_on }},${{ matrix.arch }},CMake ${{ matrix.cmake_version }})
 
     steps:
       - name: Harden Runner
@@ -79,13 +86,13 @@ jobs:
           pip install -r test/e2e/requirements.txt
 
       - name: Create vcpkg config without CMake
-        if: matrix.cmake_version != 'vcpkg'
+        if: matrix.cmake_version != '3.31.5'
         shell: bash
         run: |
           jq 'del(.requires."arm:tools/kitware/cmake")' ./test/vcpkg-configuration.json > ./test/vcpkg-configuration-temp.json
 
       - name: Setup vcpkg environment (with CMake)
-        if: matrix.cmake_version == 'vcpkg'
+        if: matrix.cmake_version == '3.31.5'
         uses: ARM-software/cmsis-actions/vcpkg@afc8e1a46fad8a5e1a08f8477b71050d442f60a7 # v1
         with:
           config: "./test/vcpkg-configuration.json"
@@ -93,7 +100,7 @@ jobs:
           cache: "-"
 
       - name: Setup vcpkg environment (without CMake)
-        if: matrix.cmake_version != 'vcpkg'
+        if: matrix.cmake_version != '3.31.5'
         uses: ARM-software/cmsis-actions/vcpkg@afc8e1a46fad8a5e1a08f8477b71050d442f60a7 # v1
         with:
           config: "./test/vcpkg-configuration-temp.json"
@@ -102,13 +109,13 @@ jobs:
 
       # Overlay CMake for non-vcpkg runs (no need to mutate the vcpkg config)
       - name: Install CMake ${{ matrix.cmake_version }} (amd64)
-        if: matrix.cmake_version != 'vcpkg' && matrix.arch == 'amd64'
+        if: matrix.cmake_version != '3.31.5' && matrix.arch == 'amd64'
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: '${{ matrix.cmake_version }}'
 
       - name: Install CMake ${{ matrix.cmake_version }} (arm64)
-        if: matrix.cmake_version != 'vcpkg' && matrix.arch == 'arm64'
+        if: matrix.cmake_version != '3.31.5' && matrix.arch == 'arm64'
         shell: bash
         run: |
           # Install CMake via pip for ARM64 compatibility
@@ -187,24 +194,17 @@ jobs:
           path: artifacts
           pattern: reports-*
 
-      - name: Consolidate robot test results (dynamic)
+      - name: Consolidate robot test results
         working-directory: artifacts
         continue-on-error: true
-        shell: bash
         run: |
-          set -euo pipefail
-          mapfile -t files < <(find . -type f -name output.xml | sort)
-          echo "Found output.xml files:"
-          printf '%s\n' "${files[@]}"
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No output.xml files found to consolidate."
-            exit 0
-          fi
-
           python -m robot.rebot --name Collective_Robot_Results \
             --outputdir collective_robot_results \
             --output output.xml \
-            "${files[@]}"
+            ./reports-windows-amd64-cmake3.31.5/output.xml \
+            ./reports-windows-amd64-cmake4.2.1/output.xml \
+            ./reports-linux-amd64-cmake3.31.5/output.xml \
+            ./reports-linux-amd64-cmake4.2.1/output.xml
 
       - name: Generate Summary report
         if: always()

--- a/test/e2e/reference.md
+++ b/test/e2e/reference.md
@@ -4,41 +4,73 @@
 
 |:white_check_mark: Passed|:x: Failed|:fast_forward: Skipped|Total|
 |:----:|:----:|:-----:|:---:|
-|32|0|0|32|
+|64|0|0|64|
 
 ## Passed Tests
 
 |Tag|Test|:clock1030: Duration|Suite|
 |:---:|:---:|:---:|:---:|
-|windows-amd64|Validate build-asm Example|25.77 s|Local Example Tests|
-|windows-amd64|Validate build-c Example|6.94 s|Local Example Tests|
-|windows-amd64|Validate build-cpp Example|10.70 s|Local Example Tests|
-|windows-amd64|Validate build-set Example|4.23 s|Local Example Tests|
-|windows-amd64|Validate executes Example|6.11 s|Local Example Tests|
-|windows-amd64|Validate include-define Example|7.85 s|Local Example Tests|
-|windows-amd64|Validate language-scope Example|10.17 s|Local Example Tests|
-|windows-amd64|Validate linker-pre-processing Example|7.09 s|Local Example Tests|
-|windows-amd64|Validate pre-include Example|7.22 s|Local Example Tests|
-|windows-amd64|Validate whitespace Example|6.97 s|Local Example Tests|
-|windows-amd64|Validate trustzone Example|48.04 s|Local Example Tests|
-|windows-amd64|Hello_FRDM-K32L3A6|35.11 s|Remote Example Tests|
-|windows-amd64|Hello_LPCXpresso55S69|30.37 s|Remote Example Tests|
-|windows-amd64|Csolution-examples|27.52 s|Remote Example Tests|
-|windows-amd64|keil-studio-get-started|8.24 s|Remote Example Tests|
-|windows-amd64|AVH-VSI|65.48 s|Remote Example Tests|
-|linux-amd64|Validate build-asm Example|8.28 s|Local Example Tests|
-|linux-amd64|Validate build-c Example|1.67 s|Local Example Tests|
-|linux-amd64|Validate build-cpp Example|2.66 s|Local Example Tests|
-|linux-amd64|Validate build-set Example|1.12 s|Local Example Tests|
-|linux-amd64|Validate executes Example|1.33 s|Local Example Tests|
-|linux-amd64|Validate include-define Example|1.93 s|Local Example Tests|
-|linux-amd64|Validate language-scope Example|2.48 s|Local Example Tests|
-|linux-amd64|Validate linker-pre-processing Example|1.69 s|Local Example Tests|
-|linux-amd64|Validate pre-include Example|1.78 s|Local Example Tests|
-|linux-amd64|Validate whitespace Example|1.67 s|Local Example Tests|
-|linux-amd64|Validate trustzone Example|7.48 s|Local Example Tests|
-|linux-amd64|Hello_FRDM-K32L3A6|13.17 s|Remote Example Tests|
-|linux-amd64|Hello_LPCXpresso55S69|10.68 s|Remote Example Tests|
-|linux-amd64|Csolution-examples|14.93 s|Remote Example Tests|
-|linux-amd64|keil-studio-get-started|3.92 s|Remote Example Tests|
-|linux-amd64|AVH-VSI|27.26 s|Remote Example Tests|
+|windows-amd64-cmake3.31.5|Validate build-asm Example|22.30 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate build-c Example|9.72 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate build-cpp Example|14.60 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate build-set Example|4.60 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate executes Example|3.81 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate include-define Example|13.07 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate language-scope Example|13.64 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate linker-pre-processing Example|10.10 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate pre-include Example|10.55 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate whitespace Example|9.90 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Validate trustzone Example|37.85 s|Local Example Tests|
+|windows-amd64-cmake3.31.5|Hello_FRDM-K32L3A6|32.06 s|Remote Example Tests|
+|windows-amd64-cmake3.31.5|Hello_LPCXpresso55S69|24.64 s|Remote Example Tests|
+|windows-amd64-cmake3.31.5|Csolution-examples|116.44 s|Remote Example Tests|
+|windows-amd64-cmake3.31.5|keil-studio-get-started|8.19 s|Remote Example Tests|
+|windows-amd64-cmake3.31.5|AVH-VSI|73.83 s|Remote Example Tests|
+|windows-amd64-cmake4.2.1|Validate build-asm Example|20.91 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate build-c Example|9.08 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate build-cpp Example|14.15 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate build-set Example|4.31 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate executes Example|3.63 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate include-define Example|13.03 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate language-scope Example|12.59 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate linker-pre-processing Example|9.09 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate pre-include Example|9.22 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate whitespace Example|8.85 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Validate trustzone Example|39.44 s|Local Example Tests|
+|windows-amd64-cmake4.2.1|Hello_FRDM-K32L3A6|31.20 s|Remote Example Tests|
+|windows-amd64-cmake4.2.1|Hello_LPCXpresso55S69|24.12 s|Remote Example Tests|
+|windows-amd64-cmake4.2.1|Csolution-examples|113.61 s|Remote Example Tests|
+|windows-amd64-cmake4.2.1|keil-studio-get-started|7.86 s|Remote Example Tests|
+|windows-amd64-cmake4.2.1|AVH-VSI|73.77 s|Remote Example Tests|
+|linux-amd64-cmake3.31.5|Validate build-asm Example|8.88 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate build-c Example|3.60 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate build-cpp Example|5.47 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate build-set Example|1.96 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate executes Example|1.46 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate include-define Example|4.70 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate language-scope Example|4.69 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate linker-pre-processing Example|3.59 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate pre-include Example|3.79 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate whitespace Example|3.57 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Validate trustzone Example|10.58 s|Local Example Tests|
+|linux-amd64-cmake3.31.5|Hello_FRDM-K32L3A6|15.06 s|Remote Example Tests|
+|linux-amd64-cmake3.31.5|Hello_LPCXpresso55S69|12.66 s|Remote Example Tests|
+|linux-amd64-cmake3.31.5|Csolution-examples|65.13 s|Remote Example Tests|
+|linux-amd64-cmake3.31.5|keil-studio-get-started|4.85 s|Remote Example Tests|
+|linux-amd64-cmake3.31.5|AVH-VSI|33.10 s|Remote Example Tests|
+|linux-amd64-cmake4.2.1|Validate build-asm Example|8.97 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate build-c Example|4.31 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate build-cpp Example|5.21 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate build-set Example|2.15 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate executes Example|1.52 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate include-define Example|4.32 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate language-scope Example|4.89 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate linker-pre-processing Example|3.83 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate pre-include Example|4.01 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate whitespace Example|3.71 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Validate trustzone Example|12.16 s|Local Example Tests|
+|linux-amd64-cmake4.2.1|Hello_FRDM-K32L3A6|18.19 s|Remote Example Tests|
+|linux-amd64-cmake4.2.1|Hello_LPCXpresso55S69|13.01 s|Remote Example Tests|
+|linux-amd64-cmake4.2.1|Csolution-examples|69.72 s|Remote Example Tests|
+|linux-amd64-cmake4.2.1|keil-studio-get-started|4.74 s|Remote Example Tests|
+|linux-amd64-cmake4.2.1|AVH-VSI|33.58 s|Remote Example Tests|


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Run E2E tests with CMake 4.2.1

**Note:** Please note that E2E test runs only with `windows-amd64` & `linux-amd64` with cmake version `3.31.5` and `4.2.1`  

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
