### PR TITLE
Update west command line syntax

### DIFF
--- a/docs/YML-Input-Format.md
+++ b/docs/YML-Input-Format.md
@@ -2069,8 +2069,8 @@ Defines for the `west build` commands are specified in CMake format. The `west-d
 The information provided with the `west:` and `west-def:` nodes are used to generate the command line for the `west` tool:
 
 ```bash
->west build --board <board> --build-dir $SolutionDir()$/out/<project-id>/$TargetType$
-            --pristine {auto | always} <west-opt> <app-path> -- <west-defs>
+>west <west-opt> build --board <board> --build-dir $SolutionDir()$/out/<project-id>/$TargetType$
+            --pristine {auto | always} <app-path> -- <west-defs>
 ```
 
 !!! Notes


### PR DESCRIPTION
It is expected that options such as `-v` will be added before `<command>`. The Toolbox is working as expected, but the documentation needs to be corrected.

```
> west --help
usage: west [-h] [-z ZEPHYR_BASE] [-v] [-q] [-V]
            <command> ...

The Zephyr RTOS meta-tool.

optional arguments:
  -h, --help            get help for west or a command
  -z ZEPHYR_BASE, --zephyr-base ZEPHYR_BASE
                        Override the Zephyr base directory. The default is
                        the manifest project with path "zephyr".
  -v, --verbose         Display verbose output. May be given multiple times
                        to increase verbosity.
  -q, --quiet           Display less verbose output. May be given multiple
                        times to decrease verbosity.
  -V, --version         print the program version and exit
```

Use case in csolution.yml:
```
    - west:
        project-id: h7_dual_core_CM7
        app-path: C:/Projects/GitHub_Repo/zephyrproject/zephyr/samples/boards/st/h7_dual_core
        board: $west-board$/m7
        device: :CM7
        west-opt:
          - -v
```