### PR TITLE
Calculate nightly toolbox version from latest released version tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -317,8 +317,14 @@ jobs:
       - name: Generate manifest file
         shell: bash
         run: |
-          # Get the toolbox version
-          TOOLBOX_VERSION=$(git describe --tags || echo "untagged")
+          # Get the toolbox version from the latest semantic version tag
+          BASE_TAG=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -n "$BASE_TAG" ]; then
+            TOOLBOX_VERSION=$(git describe --tags --match "$BASE_TAG")
+          else
+            TOOLBOX_VERSION="untagged"
+          fi
+          echo "Toolbox version: $TOOLBOX_VERSION"
 
           # Set binary extension (default to empty string if not set)
           BINARY_EXTENSION=${{ matrix.binary_extension }}


### PR DESCRIPTION
## Changes
- Bypasses `test-reference` tags by always matching against the latest. X.Y.Z release tag, ensuring accurate version and commit counts.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
