### PR TITLE
Nightly Fix: Install Node explicitly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -410,6 +410,12 @@ jobs:
         run: |
           jq 'del(.requires."arm:tools/kitware/cmake")' ./test/vcpkg-configuration.json > ./test/vcpkg-configuration-temp.json
 
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        if: runner.os == 'Windows'
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup vcpkg environment
         if: matrix.cmake_version == '3.31.5'
         uses: ARM-software/cmsis-actions/vcpkg@afc8e1a46fad8a5e1a08f8477b71050d442f60a7 # v1


### PR DESCRIPTION
## Fixes
- Fixing: vcpkg expects an old checksum for the latest Node version installed, but Node’s published file now has a different checksum.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
