### PR TITLE
[E2E] Install Node version explicitly

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -85,6 +85,12 @@ jobs:
           pip install --upgrade pip
           pip install -r test/e2e/requirements.txt
 
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        if: runner.os == 'Windows'
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Create vcpkg config without CMake
         if: matrix.cmake_version != '3.31.5'
         shell: bash
@@ -226,3 +232,4 @@ jobs:
         with:
           name: consolidated-reports
           path: artifacts/collective_robot_results
+


### PR DESCRIPTION
## Fixes
- Updating the installed Node version to resolve vcpkg SHA512 issue


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
