### PR TITLE
Disable XC test suite run on arm based runners

### DIFF
--- a/.github/matrix_includes.json
+++ b/.github/matrix_includes.json
@@ -5,7 +5,8 @@
         "arch": "amd64",
         "binary_extension": "",
         "runOnBranch":"always",
-        "runTests": false
+        "runTests": false,
+        "runsXCTestSuite": false
     },
     {
         "runs_on":"macos-14",
@@ -13,7 +14,8 @@
         "arch": "arm64",
         "binary_extension": "",
         "runOnBranch":"always",
-        "runTests": false
+        "runTests": false,
+        "runsXCTestSuite": false
     },
     {
         "runs_on":"ubuntu-22.04",
@@ -21,7 +23,8 @@
         "arch": "amd64",
         "binary_extension":"",
         "runOnBranch":"always",
-        "runTests": true
+        "runTests": true,
+        "runsXCTestSuite": true
     },
     {
         "runs_on":"ubuntu-22.04-arm",
@@ -29,7 +32,8 @@
         "arch": "arm64",
         "binary_extension":"",
         "runOnBranch":"always",
-        "runTests": true
+        "runTests": true,
+        "runsXCTestSuite": false
     },
     {
         "runs_on":"windows-2022",
@@ -37,7 +41,8 @@
         "arch": "amd64",
         "binary_extension":".exe",
         "runOnBranch":"always",
-        "runTests": true
+        "runTests": true,
+        "runsXCTestSuite": true
     },
     {
         "runs_on":"windows-2022",
@@ -45,6 +50,7 @@
         "arch": "arm64",
         "binary_extension":".exe",
         "runOnBranch":"always",
-        "runTests": false
+        "runTests": false,
+        "runsXCTestSuite": false
     }
 ]

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   matrix_prep:
     runs-on: ubuntu-latest
@@ -36,7 +40,6 @@ jobs:
       
       - name: Generate matrix with cmake versions
         id: test-matrix
-        shell: bash
         run: |
           base_matrix='${{ steps.test-matrix-base.outputs.matrix }}'
 
@@ -80,7 +83,6 @@ jobs:
           cache: 'pip'
 
       - name: Install pip dependencies
-        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install -r test/e2e/requirements.txt
@@ -93,7 +95,6 @@ jobs:
 
       - name: Create vcpkg config without CMake
         if: matrix.cmake_version != '3.31.5'
-        shell: bash
         run: |
           jq 'del(.requires."arm:tools/kitware/cmake")' ./test/vcpkg-configuration.json > ./test/vcpkg-configuration-temp.json
 
@@ -122,26 +123,22 @@ jobs:
 
       - name: Install CMake ${{ matrix.cmake_version }} (arm64)
         if: matrix.cmake_version != '3.31.5' && matrix.arch == 'arm64'
-        shell: bash
         run: |
           # Install CMake via pip for ARM64 compatibility
           pip install cmake==${{ matrix.cmake_version }}
 
       - name: Confirm CMake selected
-        shell: bash
         run: |
           echo "cmake_version matrix value: ${{ matrix.cmake_version }}"
           which cmake || true
           cmake --version
 
       - name: Activate Arm tool license
-        shell: bash
         run: |
           armlm activate --server https://mdk-preview.keil.arm.com --product KEMDK-COM0
         working-directory: ./test
 
       - name: Binary version info
-        shell: bash
         run: |
           csolution${{ matrix.binary_extension }} -V
           cpackget${{ matrix.binary_extension }} -V
@@ -150,7 +147,6 @@ jobs:
           cbuildgen${{ matrix.binary_extension }} -V
 
       - name: Run Test
-        shell: bash
         continue-on-error: true
         working-directory: ./test
         env:
@@ -189,7 +185,6 @@ jobs:
           cache: 'pip'
 
       - name: Install pip dependencies
-        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install -r test/e2e/requirements.txt
@@ -214,7 +209,6 @@ jobs:
 
       - name: Generate Summary report
         if: always()
-        shell: bash
         run: |
           python ./test/e2e/lib/execution_summary.py artifacts \
             -r ./test/e2e/reference.md \
@@ -223,7 +217,6 @@ jobs:
 
       - name: Print E2E Report
         if: always()
-        shell: bash
         run: cat summary_report.md >> $GITHUB_STEP_SUMMARY
 
       - name: Archive consolidated test results


### PR DESCRIPTION
## Fixes
- Addressing part of [Extend E2E Tests with XC toolchain](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/498)

## Changes
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/pull/518#pullrequestreview-3780000798

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
