### PR TITLE
Cleanup: E2E tests run on ubuntu-arm64

### DIFF
--- a/.github/matrix_includes.json
+++ b/.github/matrix_includes.json
@@ -32,7 +32,7 @@
         "arch": "arm64",
         "binary_extension":"",
         "runOnBranch":"always",
-        "runTests": true,
+        "runTests": false,
         "runsXCTestSuite": false
     },
     {


### PR DESCRIPTION
## Changes
- The E2E tests were executed on Ubuntu-arm64 but were failing, and their results were not included in the final output. This PR cleans up the E2E test execution, and a separate issue #530 has been created to investigate and address the underlying failures.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
