### PR TITLE
Docs update for path-type

### DIFF
--- a/docs/build-operation.md
+++ b/docs/build-operation.md
@@ -427,7 +427,7 @@ The options are added
 &nbsp;&nbsp;&nbsp; `type:`                              |**Required**| Type (enum: value list, number: value, string: name, file: name).
 &nbsp;&nbsp;&nbsp; `range:`                             |  Optional  | Value range for type int.
 &nbsp;&nbsp;&nbsp; `values:`                            |  Optional  | Value list for type enum.
-&nbsp;&nbsp;&nbsp; `path-type:`                         |  Optional  | Type of the path specified with `default:`. Possible values: `absolute` or `relative` (default). Only valid if `type:` is `file`.
+&nbsp;&nbsp;&nbsp; `path-type:`                         |  Optional  | Only valid if `type:` is `file`. Possible values: `absolute` or `relative` (default).
 &nbsp;&nbsp;&nbsp; `default:`                           |  Optional  | Default value (or enum name) for user interface when no value given in csolution.yml.
 &nbsp;&nbsp;&nbsp; `scale:`                             |  Optional  | The value in csolution.yml value is multiplied by the scale factor.
 


### PR DESCRIPTION
## Fixes
https://github.com/Open-CMSIS-Pack/debug-adapter-registry/pull/97

## Changes
Added `path-type` to documentation.

## Checklist
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
