### PR TITLE
Link checker less verbose output

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,5 +1,6 @@
 name: markdown
 on:
+  workflow_call:
   pull_request:
     paths:
       - '.github/workflows/markdown.yml'
@@ -25,9 +26,9 @@ jobs:
       - name: Checkout cmsis-toolbox
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Check markdown links
+      - name: Check Markdown Links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --config .github/lychee.toml './**/*.md'
           fail: true
-          jobSummary: true
+          jobSummary: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  markdown-link-checker:
+    if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox'
+    uses: ./.github/workflows/markdown.yml
+
   test:
     if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox'
     uses: ./.github/workflows/shared-e2e.yml


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Added link checker job to Nightly
- Removed printing of the summary on GitHub summary as it was too verbose. The same info can be obtained from action logs

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
