### PR TITLE
Increase max_retries in lychee configuration from 2 to 4

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -20,7 +20,7 @@ accept = [
 max_redirects = 2
 
 # Maximum number of allowed retries before a link is declared dead.
-max_retries = 2
+max_retries = 4
 
 # Only test links with the given schemes
 # Omit to check links with any other scheme.


### PR DESCRIPTION
## Changes
- Some services like `kb.segger.com` (or it can be anything) may occasionally return temporary errors (500 status codes) due to server maintenance, network hiccups, or transient load issues. Increasing the maximum retry attempts from 2 to 4 makes the link checker more resilient to these temporary failures while still catching genuinely broken links.

This should prevent false positives in CI/CD pipelines where a momentary server blip would otherwise fail the workflow, reducing unnecessary build interruptions while maintaining link integrity checks.

For e.g. recent builds showed 500 return code 
```
# Errors in docs/index.md
* [500] <https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases/tag/2.10.0> | Rejected status code: 500 Internal Server Error (configurable with "accept" option)

# Errors in docs/JLink-Debugger.md
* [500] <https://kb.segger.com/J-Link_GDB_Server> | Rejected status code: 500 Internal Server Error (configurable with "accept" option)
```
 
## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
