### PR TITLE
Cross repository workflow trigger

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,17 @@ name: Nightly
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *'
+    inputs:
+      trigger_extension_build:
+        description: 'Trigger the CMSIS solution extension build as part of this workflow'
+        required: false
+        default: false
+        type: boolean
+      use_nightly_devtools:
+        description: 'Use latest nightly devtools artifacts, otherwise use the latest stable build'
+        required: false
+        default: false
+        type: boolean
   pull_request:
     paths:
       - '.github/workflows/nightly.yml'
@@ -25,6 +34,8 @@ jobs:
   test:
     if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox'
     uses: ./.github/workflows/shared-e2e.yml
+    with:
+      use_nightly_devtools: ${{ github.event_name == 'workflow_dispatch' && inputs.use_nightly_devtools || false }}
     secrets:
       IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_TOKEN }}
 
@@ -221,3 +232,27 @@ jobs:
             -r ref_benchmark_results.json \
             -c curr_benchmark_results.json \
             -p 1.10
+
+  # Triggers the cmsis solution extension nightly workflow in the separate repository
+  trigger-solution-extn:
+    needs: [ performance-check ]
+    if: >-
+      success() &&
+      github.repository == 'Open-CMSIS-Pack/cmsis-toolbox' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.trigger_extension_build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Trigger vscode-cmsis-solution workflow
+        run: |
+          curl --fail-with-body --show-error --silent -X POST \
+            -H "Authorization: Bearer ${{ secrets.CROSS_REPO_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/Open-CMSIS-Pack/vscode-cmsis-solution/actions/workflows/nightly.yml/dispatches \
+            -d '{"ref":"main"}'

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: number
         default: 7
+      use_nightly_devtools:
+        description: 'Use latest nightly devtools artifacts, otherwise use the latest stable build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   matrix_prep:
@@ -78,11 +83,35 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
 
-      - name: Get latest nightly Run ID
+      - name: Get latest nightly Run ID for Open-CMSIS-Pack/devtools
         id: get_run_id
         shell: bash
         run: |
-          RUN_ID=$(gh run list --limit 1 --workflow nightly --repo Open-CMSIS-Pack/devtools --json databaseId --jq '.[0].databaseId')
+          if [ "${{ inputs.use_nightly_devtools }}" == "false" ]; then
+            RUN_ID=$(gh run list --limit 1 --workflow nightly --repo Open-CMSIS-Pack/devtools --json databaseId --jq '.[0].databaseId')
+          else
+            UTC_DATE_FILTER=$(date -u +%Y-%m-%d)
+            UTC_DATE_DISPLAY=$(date -u +%d.%m.%Y)
+            FILTER_EVENT="schedule"
+
+            LATEST_RUN=$(gh run list --limit 10 --workflow nightly --branch main --repo Open-CMSIS-Pack/devtools \
+              --json databaseId,createdAt,status,conclusion,event \
+              --jq '[ .[]
+                | select(.createdAt | startswith("'"$UTC_DATE_FILTER"'"))
+                | select(.status == "completed" and .conclusion == "success")
+                | select(.event == "'"$FILTER_EVENT"'")
+              ]
+              | sort_by(.createdAt)
+              | last // {}')
+
+            RUN_ID=$(echo "$LATEST_RUN" | jq -r '.databaseId // empty')
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+              ERR_MSG="No successful completed nightly run found for Open-CMSIS-Pack/devtools on $UTC_DATE_DISPLAY."
+              echo "$ERR_MSG"
+              echo "### :x: $ERR_MSG" >> $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
+          fi
           echo "NIGHTLY_RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 
       # Clean Go mod cache


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Arm-Debug/mcu-example-dashboard/issues/69

## Changes
- On successful completion of CMSIS-Toolbox nightly workflow trigger CMSIS CSolution extension's nightly
- Run this job only if:
   - the previous steps succeeded, AND
   - the workflow is running in the CMSIS-Toolbox repository, AND
   - It was triggered either by the `workflow_dispatch` event OR manually with `trigger_extension_build=true` 
- Consume recent runs of the nightly workflow in `Open-CMSIS-Pack/devtools` that were started manually with workflow_dispatch and ended successfully

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
