### PR TITLE
Raise warning on markdown link check failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,37 @@ env:
 jobs:
   markdown-link-checker:
     if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox'
-    uses: ./.github/workflows/markdown.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout cmsis-toolbox
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check Markdown Links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --config .github/lychee.toml --no-progress --format compact './**/*.md'
+          output: broken_links.txt
+          fail: false
+          jobSummary: false
+        continue-on-error: true
+
+      - name: Show Broken Links (if any)
+        if: always()
+        run: |
+          if [ -s broken_links.txt ]; then
+            {
+              echo "### :warning: Broken markdown links"
+              echo
+              echo '```text'
+              cat broken_links.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   test:
     if: github.repository == 'Open-CMSIS-Pack/cmsis-toolbox'

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   matrix_prep:
     runs-on: ubuntu-latest

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   matrix_prep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Updated the nightly workflow so that broken link detection no longer fails the entire nightly run.
- Instead, the workflow now raises a warning and publishes a summary of the broken links in the GitHub Actions summary.
- Example: [GitHub summary](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/actions/runs/26150324062)
- Forced workflows to use Node 24


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
