### PR TITLE
Mark job fail on any matrix job failure

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -33,7 +33,8 @@ exclude = [
   'https://www.keil.com/',
   'https://www.st.com/',
   'https://www.nxp.com/configtools',
-  'https://www.microchip.com/en-us/tools-resources'
+  'https://www.microchip.com/en-us/tools-resources',
+  'https://www.segger.com/products'
 ]
 
 # Exclude paths from getting checked. The values are treated as regular expressions

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -24,7 +24,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check Markdown Links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -29,7 +29,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
 
       - name: Setup Python
@@ -57,7 +57,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout cmsis-toolbox
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: 'gh-pages'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check Markdown Links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
@@ -83,7 +83,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout toolbox repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -152,7 +152,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBUILD_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags)" \
+          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
             -o build/cbuild${{ matrix.binary_extension }} ./cmd/cbuild
 
       # Download and build cpackget executable
@@ -178,7 +178,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CPACKGET_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags)" \
+          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
             -o build/cpackget${{ matrix.binary_extension }} ./cmd
 
       # Download and build cbuild2cmake executable
@@ -203,7 +203,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBUILD2CMAKE_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags)" \
+          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
             -o build/cbuild2cmake${{ matrix.binary_extension }} ./cmd/cbuild2cmake
 
       # Download and build vidx2pidx executable
@@ -228,7 +228,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_VIDX2PIDX_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags)" \
+          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
             -o build/vidx2pidx${{ matrix.binary_extension }} ./cmd
 
       # Download and build cbridge executable
@@ -253,7 +253,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBRIDGE_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags)" \
+          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
             -o build/cbridge${{ matrix.binary_extension }} ./cmd
 
       # Download projmgr and cbuildgen from nightly
@@ -339,11 +339,25 @@ jobs:
       - name: Generate manifest file
         shell: bash
         run: |
+          set -x
+          echo "[debug] Start manifest generation"
+          echo "[debug] Working directory: $(pwd)"
+          echo "[debug] Current commit: $(git rev-parse HEAD)"
+          echo "[debug] Tags reachable from HEAD (first 20):"
+          git tag --merged HEAD | sort -V | tail -20 || true
+
           # Get the toolbox version from the latest semantic version tag
           BASE_TAG=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          echo "[debug] BASE_TAG candidate: ${BASE_TAG:-<none>}"
           if [ -n "$BASE_TAG" ]; then
-            TOOLBOX_VERSION=$(git describe --tags --match "$BASE_TAG")
+            echo "[debug] Attempt git describe using BASE_TAG match"
+            TOOLBOX_VERSION=$(git describe --tags --match "$BASE_TAG" 2>/dev/null || true)
+            if [ -z "$TOOLBOX_VERSION" ]; then
+              echo "[debug] git describe returned no value; falling back to BASE_TAG"
+              TOOLBOX_VERSION="$BASE_TAG"
+            fi
           else
+            echo "[debug] No semantic BASE_TAG found; using untagged"
             TOOLBOX_VERSION="untagged"
           fi
           echo "Toolbox version: $TOOLBOX_VERSION"
@@ -351,12 +365,15 @@ jobs:
           # Set binary extension (default to empty string if not set)
           BINARY_EXTENSION=${{ matrix.binary_extension }}
           [ -z "$BINARY_EXTENSION" ] && BINARY_EXTENSION=""
+          echo "[debug] BINARY_EXTENSION: ${BINARY_EXTENSION:-<empty>}"
 
           # Get absolute path to the toolbox directory
           TOOLBOX_ABS_PATH=$(pwd)/cmsis-toolbox
+          echo "[debug] TOOLBOX_ABS_PATH: $TOOLBOX_ABS_PATH"
 
           # Get host machine configuration
           HOST=${{ matrix.target }}-${{ matrix.arch }}
+          echo "[debug] HOST: $HOST"
 
           # Run the Python script to generate the manifest file
           python ./scripts/generate_manifest.py \
@@ -383,9 +400,13 @@ jobs:
       - name: Create Debian Package
         if: ${{ matrix.target == 'linux' && matrix.arch == 'amd64' }}
         run: |
+            set -x
+            echo "[debug] Start Debian package generation"
             git fetch
+            echo "[debug] Current commit: $(git rev-parse HEAD)"
+            echo "[debug] Latest tag (abbrev=0) candidate: $(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)"
             mkdir -p ./debian/build
-            cmake -G Ninja -S ./debian -B ./debian/build -DTOOLBOX_ROOT=$(realpath ./cmsis-toolbox) -DTOOLBOX_VERSION=$(git describe --tags --abbrev=0)+nightly-$(date +%Y%m%d%H%M)
+            cmake -G Ninja -S ./debian -B ./debian/build -DTOOLBOX_ROOT=$(realpath ./cmsis-toolbox) -DTOOLBOX_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)+nightly-$(date +%Y%m%d%H%M)
             cd ./debian/build
             cpack -G DEB
 

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: JoshuaTheMiller/conditional-build-matrix@81b51eb8d89e07b86404934b5fecde1cea1163a5 # v2.0.1
         id: build-matrix
@@ -80,9 +80,10 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Authenticate with GitHub CLI
         shell: bash
@@ -131,7 +132,7 @@ jobs:
 
       # Download and build cbuild executable
       - name: Checkout cbuild repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/cbuild
           path: cbuild
@@ -156,7 +157,7 @@ jobs:
 
       # Download and build cpackget executable
       - name: Checkout cpackget repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/cpackget
           path: cpackget
@@ -182,7 +183,7 @@ jobs:
 
       # Download and build cbuild2cmake executable
       - name: Checkout cbuild2cmake repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/cbuild2cmake
           path: cbuild2cmake
@@ -207,7 +208,7 @@ jobs:
 
       # Download and build vidx2pidx executable
       - name: Checkout vidx2pidx repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/vidx2pidx
           path: vidx2pidx
@@ -232,7 +233,7 @@ jobs:
 
       # Download and build cbridge executable
       - name: Checkout cbridge repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/generator-bridge
           path: cbridge
@@ -280,7 +281,7 @@ jobs:
           fi
 
       - name: Checkout Open-CMSIS-PACK/devtools repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: Open-CMSIS-PACK/devtools
           path: devtools
@@ -411,7 +412,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout toolbox repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -542,7 +543,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -70,8 +70,8 @@ jobs:
     name: Create toolbox [${{ matrix.target }}-${{ matrix.arch }}]
     needs: [ matrix_prep ]
     runs-on: ${{ matrix.runs_on }}
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.matrix_prep.outputs.build) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/shared-e2e.yml
+++ b/.github/workflows/shared-e2e.yml
@@ -152,7 +152,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBUILD_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
             -o build/cbuild${{ matrix.binary_extension }} ./cmd/cbuild
 
       # Download and build cpackget executable
@@ -178,7 +178,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CPACKGET_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
             -o build/cpackget${{ matrix.binary_extension }} ./cmd
 
       # Download and build cbuild2cmake executable
@@ -203,7 +203,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBUILD2CMAKE_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
             -o build/cbuild2cmake${{ matrix.binary_extension }} ./cmd/cbuild2cmake
 
       # Download and build vidx2pidx executable
@@ -228,7 +228,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_VIDX2PIDX_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
             -o build/vidx2pidx${{ matrix.binary_extension }} ./cmd
 
       # Download and build cbridge executable
@@ -253,7 +253,7 @@ jobs:
           GOOS=${{ matrix.target }} \
           GOARCH=${{ matrix.arch }} \
           GOMODCACHE=$ABS_CBRIDGE_GOMODCACHE \
-          go build -ldflags "-X main.version=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)" \
+          go build -ldflags "-X main.version=$(git describe --tags)" \
             -o build/cbridge${{ matrix.binary_extension }} ./cmd
 
       # Download projmgr and cbuildgen from nightly
@@ -339,25 +339,11 @@ jobs:
       - name: Generate manifest file
         shell: bash
         run: |
-          set -x
-          echo "[debug] Start manifest generation"
-          echo "[debug] Working directory: $(pwd)"
-          echo "[debug] Current commit: $(git rev-parse HEAD)"
-          echo "[debug] Tags reachable from HEAD (first 20):"
-          git tag --merged HEAD | sort -V | tail -20 || true
-
           # Get the toolbox version from the latest semantic version tag
           BASE_TAG=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
-          echo "[debug] BASE_TAG candidate: ${BASE_TAG:-<none>}"
           if [ -n "$BASE_TAG" ]; then
-            echo "[debug] Attempt git describe using BASE_TAG match"
-            TOOLBOX_VERSION=$(git describe --tags --match "$BASE_TAG" 2>/dev/null || true)
-            if [ -z "$TOOLBOX_VERSION" ]; then
-              echo "[debug] git describe returned no value; falling back to BASE_TAG"
-              TOOLBOX_VERSION="$BASE_TAG"
-            fi
+            TOOLBOX_VERSION=$(git describe --tags --match "$BASE_TAG")
           else
-            echo "[debug] No semantic BASE_TAG found; using untagged"
             TOOLBOX_VERSION="untagged"
           fi
           echo "Toolbox version: $TOOLBOX_VERSION"
@@ -365,15 +351,12 @@ jobs:
           # Set binary extension (default to empty string if not set)
           BINARY_EXTENSION=${{ matrix.binary_extension }}
           [ -z "$BINARY_EXTENSION" ] && BINARY_EXTENSION=""
-          echo "[debug] BINARY_EXTENSION: ${BINARY_EXTENSION:-<empty>}"
 
           # Get absolute path to the toolbox directory
           TOOLBOX_ABS_PATH=$(pwd)/cmsis-toolbox
-          echo "[debug] TOOLBOX_ABS_PATH: $TOOLBOX_ABS_PATH"
 
           # Get host machine configuration
           HOST=${{ matrix.target }}-${{ matrix.arch }}
-          echo "[debug] HOST: $HOST"
 
           # Run the Python script to generate the manifest file
           python ./scripts/generate_manifest.py \
@@ -400,13 +383,9 @@ jobs:
       - name: Create Debian Package
         if: ${{ matrix.target == 'linux' && matrix.arch == 'amd64' }}
         run: |
-            set -x
-            echo "[debug] Start Debian package generation"
             git fetch
-            echo "[debug] Current commit: $(git rev-parse HEAD)"
-            echo "[debug] Latest tag (abbrev=0) candidate: $(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)"
             mkdir -p ./debian/build
-            cmake -G Ninja -S ./debian -B ./debian/build -DTOOLBOX_ROOT=$(realpath ./cmsis-toolbox) -DTOOLBOX_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)+nightly-$(date +%Y%m%d%H%M)
+            cmake -G Ninja -S ./debian -B ./debian/build -DTOOLBOX_ROOT=$(realpath ./cmsis-toolbox) -DTOOLBOX_VERSION=$(git describe --tags --abbrev=0)+nightly-$(date +%Y%m%d%H%M)
             cd ./debian/build
             cpack -G DEB
 

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: JoshuaTheMiller/conditional-build-matrix@81b51eb8d89e07b86404934b5fecde1cea1163a5 # v2.0.1
         id: set-matrix
         with:
@@ -67,7 +67,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -417,7 +417,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout cmsis-toolbox
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Changes
- Updated version of action/checkout
- Set job `fail-fast: false` to mark the overall job fail when failure happens

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
