### PR TITLE
*.cbuild-run.yml: Add `project:` for `output:` entries, rename `traceSetup:` to `trace-setup:`

### DIFF
--- a/docs/YML-CBuild-Format.md
+++ b/docs/YML-CBuild-Format.md
@@ -839,6 +839,7 @@ cbuild-run:
       type: svd
   output:
     - file: out/CubeMX/MyBoard_ROM/Debug/CubeMX.axf
+      project: CubeMX
       type: elf
 
   system-resources:
@@ -892,6 +893,7 @@ The `output:` node also contains other required files that are added with [`imag
 `output:`                                                 |             | Content
 :---------------------------------------------------------|-------------|:------------------------------------
 `- file:`                                                 |**Required** | Specifies the file name.
+&nbsp;&nbsp;&nbsp; `project:`                             |  Optional   | Project associated with the image file.
 &nbsp;&nbsp;&nbsp; [`type:`](YML-Input-Format.md#type)    |**Required** | Specifies the file type.
 &nbsp;&nbsp;&nbsp; `info:`                                |  Optional   | Brief description of the file.
 &nbsp;&nbsp;&nbsp; [`load:`](YML-Input-Format.md#load)    |**Required** | Load mode of the image file for programmers and debug tools.

--- a/docs/YML-CBuild-Format.md
+++ b/docs/YML-CBuild-Format.md
@@ -1275,9 +1275,9 @@ This node contains configuration information for how [debug sequences](https://o
 
 `debug-sequences-conf:`              |              | Content
 :------------------------------------|--------------|:------------------------------------
-&nbsp;&nbsp;&nbsp; `traceSetup:`     |   Optional   | Configure how to use trace sequences. Can be `full` or `legacy` (default: `legacy`).
+&nbsp;&nbsp;&nbsp; `trace-setup:`     |   Optional   | Configure how to use trace sequences. Can be `full` or `legacy` (default: `legacy`).
 
-Value `full` for `traceSetup:` informs the debugger that all trace component setup is done by the trace sequences. Opposed to that, the `legacy` mode expected debuggers to program the CoreSight trace components as per built-in support knowledge. Going forward, `full` is the preferred mode to allow new CoreSight component support without debug tool updates.
+Value `full` for `trace-setup:` informs the debugger that all trace component setup is done by the trace sequences. Opposed to that, the `legacy` mode expected debuggers to program the CoreSight trace components as per built-in support knowledge. Going forward, `full` is the preferred mode to allow new CoreSight component support without debug tool updates.
 
 ```yml
 debug-sequences:
@@ -1285,7 +1285,7 @@ debug-sequences:
        :
 
 debug-sequences-conf:
-  traceSetup: full
+  trace-setup: full
 ```
 
 


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- Part of #644 
- Part of #650 

## Changes
<!-- List the changes this PR introduces -->
- Add optional `project:` node for `output:` entries for `*.cbuild-run.yml`
- Rename `traceSetup:` under `debug-sequences-conf:` to `trace-setup:`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
