### PR TITLE
Add timestamp clock and ctrace-setup node

### DIFF
--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -404,7 +404,7 @@ The `pcsampling:` node enables DWT PC sampling.
 
 `pcsampling:`                         |             | Content
 :-------------------------------------|:------------|:------------------------------------
-`- period:`                           |  Optional   | Sampling period in CPU cycles.
+`period:`                             |  Optional   | Sampling period in CPU cycles.
 
 Supported values for `period:` `0` (off), `64`, `128`, `256`, ..., `16384`. Default: `0`.
 

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -263,7 +263,7 @@ The `*.ctrace.yml` file starts with the node `ctrace:` and contains the trace ca
 
 `ctrace:`                                               |             | Content
 :-------------------------------------------------------|:------------|:------------------------------------
-&nbsp;&nbsp;&nbsp; `created-by:`                        |  Optional   | Tool and version that created or last updated the file.
+&nbsp;&nbsp;&nbsp; `generated-by:`                      |  Optional   | Tool and version that generated or last updated the file.
 &nbsp;&nbsp;&nbsp; `setup:`                             |  Required   | Setup for each processor.
 
 `setup:`                                                  |             | Content

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -290,6 +290,7 @@ ctrace:
     - pname: 
 #     disable:    # disables trace without need to remove settings
       timestamps:
+        clock: 24000000
       timesync:
 
       data:
@@ -323,7 +324,10 @@ When `timestamps:` is present, timestamp generation is enabled in the trace stre
 
 `timestamps:`                                            |             | Content
 :--------------------------------------------------------|:------------|:------------------------------------
+&nbsp;&nbsp;&nbsp; `clock:`                              |  Optional   | Timestamp clock frequency in Hz.
 &nbsp;&nbsp;&nbsp; `itm-prescaler:`                      |  Optional   | ITM timestamp prescaler: `1` (default), `4`, `16`, `64`.
+
+The timestamp `clock` typically is the processor clock.
 
 #### `timesync:`
 
@@ -456,7 +460,10 @@ The `*.ctrace-run.yml` file starts with the node `ctrace-run:`. It is generated 
 `ctrace-run:`                                            |             | Content
 :--------------------------------------------------------|:------------|:------------------------------------
 &nbsp;&nbsp;&nbsp; `generated-by:`                       |  Optional   | Tool and version that generated the file.
+&nbsp;&nbsp;&nbsp; `ctrace-setup:`                       |  Optional   | Copy of [`setup`](#file-structure-of-ctraceyml) node in the `*.ctrace.yml` file.
 &nbsp;&nbsp;&nbsp; `ctrace-refs:`                        |**Required** | List of [references](#references) in the `*.ctrace.yml` file.
+
+The `ctrace-setup` node uses the same format as the [`setup`](#file-structure-of-ctraceyml) node in the `*.ctrace.yml` file and preserves the original user input for consumers of the `*.ctrace-run.yml` file. This includes settings that do not resolve to a `ctrace-ref` but are required for higher-level output formats such as CTF. For example the `timestamps:clock` node.
 
 `ctrace-refs:`                                           |             | Content
 :--------------------------------------------------------|:------------|:------------------------------------
@@ -474,6 +481,8 @@ The `*.ctrace-run.yml` file starts with the node `ctrace-run:`. It is generated 
 &nbsp;&nbsp;&nbsp; `regs:`                               |  Optional   | Register setup.
 
 The trace source types are: `dwt`, `event`, `exception`, `itm`, `pmu`, `overflow`, `pcsample`, `global_ts`.
+
+Multiple `ctrace-ref` entries may reference the same configuration node when it generates setups for multiple streams. The combination of `ctrace-ref` and `stream` identifies each generated setup.
 
 The meaning of `source:` depends on the `type:` as shown below.
 
@@ -522,6 +531,26 @@ ctrace-run:
         mask:  0xFF
       - name: DWT_COMP1
         value: 2
+
+  - ctrace-ref: core0/timestamps
+    type: itm
+    pname: core0
+    stream: 1
+    regs:
+      - name: ITM_TCR
+        value: 0x00000002
+        mask: 0x00000002
+
+  # - ctrace-ref: core0/timestamps
+  #   type: etm            # etm not yet supported, for demonstration purposes only
+  #   pname: core0
+  #   stream: 2
+  #   regs:
+  #     - name: TRCCONFIGR
+  #       value: 0x00000010
+  #       mask: 0x00000010
+  #     - name: TRCCCCTLR
+  #       value: 0x4
 ```
 
 #### Register Accesses
@@ -535,7 +564,7 @@ Trace Component | Base Address | Description
 `PMU`           | `0xE0003000` | Performance Monitoring Unit.
 `ETM`           | `0xE0041000` | Embedded Trace Macrocell.
 
-The `ctrace-ref:` node references the trace generation configuration in the file `*.ctrace.yml` and contains register values that represent the setup.
+The `ctrace-ref:` node references the trace generation configuration in the file `*.ctrace.yml` and contains register values that represent the setup for trace sources.
 A single-core system has no `pname:` value; a multi-processor always includes a `pname:` value in the `ctrace-ref:` node.
 
 ### Initial Implementation
@@ -723,9 +752,9 @@ File           | Description
 
 ## Processor-Specific Trace Features
 
-The following information lists the Cortex-M processors and the DWT, ITM, ETM, MTB, and PMU implementation options.
+TODO: Discard most of the following chapters. Condensed in table further above.
 
-ToDo: how are implementation options obtained?
+The following information lists the Cortex-M processors and the DWT, ITM, ETM, MTB, and PMU implementation options.
 
 ### Processor Trace Capabilities
 

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -414,7 +414,7 @@ The `synchronization:` node specifies the frequency of the DWT synchronization p
 
 `synchronization:`                    |             | Content
 :-------------------------------------|:------------|:------------------------------------
-`- DWT:`                              |**Required** | Frequency `0` (off), `16M`, `64M`, `256M` processor cycles. Default: `256M`.
+`- DWT:`                              |**Required** | Frequency `off`, `16M`, `64M`, `256M` processor cycles. Default: `256M`.
 
 **Example:**
 


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
N/A

## Changes
<!-- List the changes this PR introduces -->
- Adds `clock` to `*.ctrace` `timestamps`. Required to calculate timestamps in time for CTF format.
  - Does NOT add a symbol name as discussed a few times before. Would only work for connected CPUs in interactive mode without major extra effort, but not in CI mode and not for unconnected CPUs.
- Adds `ctrace-setup` to `*.ctrace-run.yml` which contains the original user input. Including settings like `clock` which do not have a `ctrace-ref` with register accesses.
- Explain that multiple `ctrace-refs` can exist if they apply to multiple streams, e.g. timestamp enable for ITM and ETM.

Note: Branch contained a version with extended `ctrace-ref` `type` to include meta-information instead of real trace packet types. Reverted this as it broke with a clear and simple pattern for `ctrace-ref`.