### PR TITLE
Update pyocd Trace Default File Names

### DIFF
--- a/docs/pyOCD-Debugger.md
+++ b/docs/pyOCD-Debugger.md
@@ -311,11 +311,14 @@ Device-specific trace capture capabilities are configured using the [`device-set
 
 The `trace:` node has one child type per supported trace transport mode which offers mode-specific options. Currently, the [`swo-uart`](#swo-uart) type and the [`trace-buffer`](#trace-buffer) type are supported.
 
-The default trace output file and location is derived from the [`cbuild-run.yml` file](YML-CBuild-Format.md#run-and-debug-management)
-and uses the format `<solution-name>+<target-type>+<trace-config-name>.trace`.  
-The `<trace-config-name>` part is derived from the optional name of the configuration stored in the type node, i.e.
-[`- swo-uart:`](#swo-uart) and the [`- trace-buffer:`](#trace-buffer). If no name is provided, the type itself is used.
+The default trace output file and location is derived from the [`cbuild-run.yml` file](YML-CBuild-Format.md#run-and-debug-management). It
+is located in the solution's `.trace/` sub-folder and uses the format `<solution-name>+<target-type>@<target-set>.<channel>.raw`.
+The `<channel>` part is derived from the type node as it follows.
 
+Type node                          | `<channel>` |
+:----------------------------------|:------------|
+[`- swo-uart:`](#swo-uart)         | SWO         |
+[`- trace-buffer:`](#trace-buffer) | TB          |
 
 !!! Note
     The `trace:` node is implemented as a list. However, currently only one node is supported. Additional nodes are ignored.
@@ -335,7 +338,7 @@ Configuration for the SWO trace output in UART mode.
 `- swo-uart:`                            | **Required** | Transport mode is SWO UART. The node allows an optional name (default: `null`).
 &nbsp;&nbsp;&nbsp; `mode:`               |   Optional   | Trace: `off` (default), `server`, `file`.
 &nbsp;&nbsp;&nbsp; `server-port:`        |   Optional   | Set TCP/IP port number of trace server in `server` mode (default: 5555).
-&nbsp;&nbsp;&nbsp; `file:`               |   Optional   | Explicit path and name of the trace output file in `file` mode. Default: `<solution-name>+<target-type>+<trace-config-name>.trace`.
+&nbsp;&nbsp;&nbsp; `file:`               |   Optional   | Explicit path and name of the trace output file in `file` mode. Default: `<solution-name>+<target-type>@<target-set>.SWO.raw`.
 &nbsp;&nbsp;&nbsp; `input-clock:`        | **Required** | Trace input clock frequency in Hz.
 &nbsp;&nbsp;&nbsp; `output-clock:`       |   Optional   | Trace output clock frequency, i.e. the baudrate, for the SWO output.
 
@@ -353,7 +356,7 @@ and configured through the `device-settings:` or the `*.dbgconf` file.
 `- trace-buffer:`                        | **Required** | Transport mode is (on-chip) trace buffer. The node allows an optional name (default: `null`).
 &nbsp;&nbsp;&nbsp; `mode:`               |   Optional   | Trace: `off` (default), `server`, `file`.
 &nbsp;&nbsp;&nbsp; `server-port:`        |   Optional   | Set TCP/IP port number of trace server in `server` mode (default: 5555).
-&nbsp;&nbsp;&nbsp; `file:`               |   Optional   | Explicit path and name of the trace output file in `file` mode. Default: `<solution-name>+<target-type>+<trace-config-name>.trace`.
+&nbsp;&nbsp;&nbsp; `file:`               |   Optional   | Explicit path and name of the trace output file in `file` mode. Default: `<solution-name>+<target-type>@<target-set>.TB.raw`.
 
 #### Trace Clocks
 


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->

Aligns preliminary specifications around default trace file names to avoid confusion during initial implementations.

## Changes
<!-- List the changes this PR introduces -->
- Aligns description of default file names in [`pyOCD-Debugger`](https://open-cmsis-pack.github.io/cmsis-toolbox/pyOCD-Debugger/#trace) docs with experimental [trace specification](https://open-cmsis-pack.github.io/cmsis-toolbox/Experimental-Features/#directory-and-file-structure).
- Keeps optional trace configuration name as part of the default file name. However, now always uses the type node based ID. Can be changed again if multiple configs of same type are needed in future.

FYI: @TeoMahnic 

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
