### PR TITLE
Relax nightly performance regression threshold to 15%

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -263,11 +263,11 @@ jobs:
           # Run the performance regression check script
           # -r: Path to the reference benchmark results (from last known reference)
           # -c: Path to the current benchmark results (from the latest run)
-          # -p: Permissible limit multiplier (e.g., 1.10 allows up to 10% permissible degrade)
+          # -p: Permissible limit multiplier (e.g., 1.15 allows up to 15% permissible degrade)
           python ./performance/check_perf_regression.py \
             -r ref_benchmark_results.json \
             -c curr_benchmark_results.json \
-            -p 1.10
+            -p 1.15
 
   # Triggers the cmsis solution extension nightly workflow in the separate repository
   trigger-solution-extn:


### PR DESCRIPTION
## Fixes
-

## Changes
- Increase the nightly performance regression multiplier from `1.10` to `1.15`, allowing up to 15% degradation.

## Checklist
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

**Risk/Follow-up:** The relaxed threshold may allow larger performance regressions before the nightly check fails.