### PR TITLE
trigger-solution-extn job should always run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -271,8 +271,9 @@ jobs:
 
   # Triggers the cmsis solution extension nightly workflow in the separate repository
   trigger-solution-extn:
+    needs: [ performance-check ]
     if: >-
-      success() &&
+      always() &&
       github.repository == 'Open-CMSIS-Pack/cmsis-toolbox' &&
       github.event_name == 'workflow_dispatch' &&
       inputs.trigger_extension_build


### PR DESCRIPTION
## Changes
- Triggering the CMSIS solution extension job should be last and should not depend on the result of the performance-check job

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
