### PR TITLE
`*.ctrace-run.yml`: `info:`, `warning:`, `error:` can be list of strings

### DIFF
--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -513,6 +513,8 @@ The `ctrace-setup` node uses the same format as the [`setup`](#file-structure-of
 
 The trace source types are: `dwt`, `event`, `exception`, `itm`, `pmu`, `overflow`, `pcsample`, `global_ts`.
 
+Each of the `info:`, `warning:`, and `error:` nodes accepts either a string or a list of strings, allowing multiple messages to be represented separately.
+
 Multiple `ctrace-ref` entries may reference the same configuration node when it generates setups for multiple streams. The combination of `ctrace-ref` and `stream` identifies each generated setup.
 
 The `data-type` in combination with `size` provides a hint for the display format. Other information required for generating CTF data can be extracted from the referenced setting node in the `ctrace-setup:` section.


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
N/A

## Changes
<!-- List the changes this PR introduces -->
- `*.ctrace-run.yml`: Allows `ctrace-ref`:'s `info:`, `warning:`, `error:` to be either a string or a list of strings. The latter allows to collect for example multiple errors during resolution of a settings node in a structured way.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
