### PR TITLE
Change CSV offset to address

### DIFF
--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -763,8 +763,7 @@ Column      | Armv7-M       | Armv8-M
 
 `pc` and `address` payloads shorter than 4 bytes replace the corresponding lower bytes of the address programmed into the DWT comparator.
 
-For packet type `pcsample`, `pc` has a 4-byte payload. On Armv8-M, 1-byte payloads have special meanings: `0x00`
-indicates that the processor is sleeping, and `0xFF` indicates that trace is prohibited for the code region.
+For packet type `pcsample`, `pc` normally has a 4-byte payload. 1 byte payloads have a special meaning: `0x00` indicates that the processor is sleeping. Armv8-M adds `0xFF` to indicate that trace is prohibited for the executed code region.
 
 !!! Note
     The timestamp packet type information is provided in the `cycles` column.

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -749,6 +749,9 @@ The following table contains details about the packet type. Information is empty
 `overflow`  | Marks an overflow, reason can be an overflow packet or an internal decoder overflow.
 `error`     | Decode error, for example unexpected trace byte values. `note` field carries details.
 
+!!! Note
+    The timestamp packet type information is provided in the `cycles` column.
+
 #### Variable Data Sizes
 
 For the `value`, `pc`, and `address` columns, the number of hex digits represents the payload size: 1 byte: `0x00`, 2 bytes: `0x0000`, 4 bytes: `0x00000000`.
@@ -763,10 +766,14 @@ Column      | Armv7-M       | Armv8-M
 
 `pc` and `address` payloads shorter than 4 bytes replace the corresponding lower bytes of the address programmed into the DWT comparator.
 
-For packet type `pcsample`, `pc` normally has a 4-byte payload. 1 byte payloads have a special meaning: `0x00` indicates that the processor is sleeping. Armv8-M adds `0xFF` to indicate that trace is prohibited for the executed code region.
+#### PC Sampling Markers
 
-!!! Note
-    The timestamp packet type information is provided in the `cycles` column.
+For packet type `pcsample`, raw trace data normally has a 4-byte payload which is shown in the `pc` column. 1 byte payloads are special markers indicating that the program counter value could not be traced. `pc` is empty in these cases, and the corresponding message is written to the `note` column.
+
+Value                 | `note`
+:---------------------|:--------------
+`0x00`                | `CPU Sleeping`
+`0xFF` (Armv8-M only) | `Trace prohibited`
 
 **Exception State Transition:**
 

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -733,10 +733,7 @@ Column         | Description
 `address`      | Data address for packet type `dwt`.
 `note`         | Additional details, used for error notification.
 
-The `value`, `pc`, and `address` columns use hexadecimal form. The number of hex digits represents the payload width:
-1 byte: `0x00`, 2 bytes: `0x0000`, 4 bytes: `0x00000000`. `value` can have any of these sizes on all architectures;
-`pc` and `address` can have them only on Armv8-M. Except for special values, `pc` and `address` payloads shorter than
-4 bytes replace the corresponding lower bytes of the address programmed into the DWT comparator.
+The `value`, `pc`, and `address` columns use hexadecimal form. See [Variable Data Sizes](#variable-data-sizes) for details.
 
 The following table contains details about the packet type. Information is empty when not provided by the trace packet.
 
@@ -747,10 +744,27 @@ The following table contains details about the packet type. Information is empty
 `event`     | Reserved for profiling/event-counter rows. Detailed semantics will be specified in a future version.
 `pmu`       | Reserved for PMU counter rows. Detailed semantics will be specified in a future version.
 `exception` | `source` = exception number. `value` = exception state transition.
-`pcsample`  | `pc` = program counter. For Armv8-M, 1-byte payloads have special meaning: `0x00` - processor is sleeping, `0xFF` trace is prohibited for the code region.
+`pcsample`  | `pc` = program counter.
 `global_ts` | Global timestamp for synchronization between streams.
 `overflow`  | Marks an overflow, reason can be an overflow packet or an internal decoder overflow.
 `error`     | Decode error, for example unexpected trace byte values. `note` field carries details.
+
+#### Variable Data Sizes
+
+For the `value`, `pc`, and `address` columns, the number of hex digits represents the payload size: 1 byte: `0x00`, 2 bytes: `0x0000`, 4 bytes: `0x00000000`.
+
+For packet type `dwt`, payload sizes depend on the architecture:
+
+Column      | Armv7-M       | Armv8-M
+:-----------|:--------------|:--------------
+`value`     | 1, 2, or 4 bytes | 1, 2, or 4 bytes
+`pc`        | 4 bytes       | 1, 2, or 4 bytes
+`address`   | 2 bytes       | 1, 2, or 4 bytes
+
+`pc` and `address` payloads shorter than 4 bytes replace the corresponding lower bytes of the address programmed into the DWT comparator.
+
+For packet type `pcsample`, `pc` has a 4-byte payload. On Armv8-M, 1-byte payloads have special meanings: `0x00`
+indicates that the processor is sleeping, and `0xFF` indicates that trace is prohibited for the code region.
 
 !!! Note
     The timestamp packet type information is provided in the `cycles` column.

--- a/docs/Experimental-Features.md
+++ b/docs/Experimental-Features.md
@@ -728,21 +728,26 @@ Column         | Description
 `stream`       | Stream ID (CoreSight ATB ID) of the trace packet. Empty if no formatting.
 `type`         | Packet type: `itm`, `dwt`, `event`, `pmu`, `exception`, `pcsample`, `global_ts`, `overflow`, `error`.
 `source`       | Source ID: ITM channel, DWT comparator, exception number, or hardware discriminator.
-`value`        | Value in hexadecimal form. Payload width is represented by the number of hex digits: 1 byte: `0x00`, 2 bytes: `0x0000`, 4 bytes: `0x00000000`. For packet type `exception` state transition: `0x1` enter, `0x2` exit, `0x3` return.
-`pc`           | Program counter for packet types `dwt` and `pcsample` (hexadecimal format, example `0x08001234`).
-`offset`       | Data address offset for packet type `dwt` (hexadecimal format, example `0xfdf9`).
+`value`        | Value in hexadecimal form. For packet type `exception` state transition: `0x1` enter, `0x2` exit, `0x3` return.
+`pc`           | Program counter for packet types `dwt` and `pcsample`.
+`address`      | Data address for packet type `dwt`.
 `note`         | Additional details, used for error notification.
+
+The `value`, `pc`, and `address` columns use hexadecimal form. The number of hex digits represents the payload width:
+1 byte: `0x00`, 2 bytes: `0x0000`, 4 bytes: `0x00000000`. `value` can have any of these sizes on all architectures;
+`pc` and `address` can have them only on Armv8-M. Except for special values, `pc` and `address` payloads shorter than
+4 bytes replace the corresponding lower bytes of the address programmed into the DWT comparator.
 
 The following table contains details about the packet type. Information is empty when not provided by the trace packet.
 
 `type`      | Description
 :-----------|:------------------------------------
 `itm`       | `source` = ITM channel.
-`dwt`       | `source` = DWT comparator, `value` = data value, `offset` = data address offset, `pc` = program counter.
+`dwt`       | `source` = DWT comparator, `value` = data value, `address` = data address, `pc` = program counter.
 `event`     | Reserved for profiling/event-counter rows. Detailed semantics will be specified in a future version.
 `pmu`       | Reserved for PMU counter rows. Detailed semantics will be specified in a future version.
 `exception` | `source` = exception number. `value` = exception state transition.
-`pcsample`  | `pc` = program counter.
+`pcsample`  | `pc` = program counter. For Armv8-M, 1-byte payloads have special meaning: `0x00` - processor is sleeping, `0xFF` trace is prohibited for the code region.
 `global_ts` | Global timestamp for synchronization between streams.
 `overflow`  | Marks an overflow, reason can be an overflow packet or an internal decoder overflow.
 `error`     | Decode error, for example unexpected trace byte values. `note` field carries details.
@@ -762,7 +767,7 @@ Value | State    | Meaning
 **Example:**
 
 ```csv
-cycles,stream,type,source,value,pc,offset,note
+cycles,stream,type,source,value,pc,address,note
 2518192,,itm,0,0x53,,,
 2518404,,itm,0,0x54,,,
 2518616,,itm,0,0x4d,,,
@@ -776,7 +781,7 @@ cycles,stream,type,source,value,pc,offset,note
 950389420,,exception,0,0x3,,,
 ```
 
-cycles    | stream | type      | source | value      | pc         | offset  | note
+cycles    | stream | type      | source | value      | pc         | address | note
 :---------|:-------|:----------|:-------|:-----------|:-----------|:--------|:-----
 2518192   |        | itm       | 0      | 0x53       |            |         |
 2518404   |        | itm       | 0      | 0x54       |            |         |


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- v8-M adds additional data compression for data address packets (beyond the 16 bit from v7-M) and PC packets.
- v8-M adds 1-byte payload variants for PC samples that indicate untraceable processors states (sleep, trace prohibited).
- Chosen `offset` name in CSV was misleading. The traced values are not an offset but replace the lower bytes of address programmed into the corresponding DWT comparator.

## Changes
<!-- List the changes this PR introduces -->
- Rename CSV column `offset` to `address`.
- Extend description of variable data sizes for `value`/`pc`/`address`  columns.

Note: This change preserves the concept of showing CSV data as close as possible to the trace packets. Hence, it currently does NOT create complete address/PC values where compression applied. This could be extended later by a command line switch to create such completed addresses. Or deferred to a display tool which then also reads `*.ctrace-run.yml`.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
